### PR TITLE
Removing cache from workflows for failing build

### DIFF
--- a/.github/workflows/pypi-relase.yaml
+++ b/.github/workflows/pypi-relase.yaml
@@ -11,10 +11,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
-        cache: 'pip'
     - name: Install dependencies
       run: |
         pip install --upgrade wheel twine


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Caching pip requires use of a requirements.txt file, we don't use this as we just have an `install_requires=["cloudformation-cli>=0.2.23"]` in the `setup.py` file. The cloudformation-cli-java-plugin also does not include a `requirements.txt `and does not use a cached pip in the [GitHub workflow](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/.github/workflows/pypi-release.yaml)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
