### PR TITLE
Enable-lambda-invoker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To get more details about hook versions registered in your account, use the `des
 - Target types
 - Testing status
 
-The details for the default version will be returned by deafult. Optionally, the `--version-id` can be passed to describe a specific version.
+The details for the default version will be returned by default. Optionally, the `--version-id` can be passed to describe a specific version.
 
 ```bash
 cfn hook describe
@@ -105,7 +105,29 @@ ConfigurationArn: arn:aws:cloudformation:us-east-1:000000000000:type-configurati
 
 ## Experimental Commands
 
-To enable experimental commands: you can set
+To enable experimental commands: you can set the environment variable: `export CFN_CLI_HOOKS_EXPERIMENTAL=enabled`.
+
+### Command: enable-lambda-invoker
+
+To activate and set the type configuration of the `AWSSamples::LambdaInvoker::Hook` 3rd party hook, use the `enable-lambda-invoker` command.
+
+This hook will invoke the lambda that is passed as the `lambda-arn` argument. Optionally, `failure-mode`, `execution-role-arn`, `alias`, and `include-targets` can all be specified with the following behavior:
+
+- `failure-mode` changes the failure mode to either `FAIL` or `WARN` (Default is `FAIL`).
+- `execution-role-arn` changes the execution role for this hook to use during runtime (Default is the role used to activate the type).
+- `alias` changes the type name for this hook in your account. For example, this can be used to change `AWSSamples::LambdaInvoker::Hook` to `MyCompany::MyOrganization::S3BucketCheckHook`. Note: If `alias` is specified, `execution-role-arn` must also be specified.
+- `include-targets` filters the targets (resource types) for which this hook will be invoked. This can be passed as a comma-seperated string (ex. `--include-targets "AWS::S3::*,AWS::DynamoDb::Table"`). (Default is ALL resource types)
+
+Note: This command does not need to be run from inside an a pre-initialized Hooks project directory.
+
+```bash
+cfn hook enable-lambda-invoker --lambda-arn arn:aws:lambda:us-east-2:123456789012:function:my-function:1
+```
+
+Sample output:
+```
+Success: AWSSamples::LambdaInvoker::Hook will now be invoked for CloudFormation deployments for ALL resources in FAIL mode.
+```
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ Optionally, `--failure-mode`, `--alias`, and `--include-targets` can all be spec
 - `--alias` changes the type name for this hook in your account. For example, this can be used to change `AWSSamples::LambdaFunctionInvoker::Hook` to `MyCompany::MyOrganization::S3BucketCheckHook`.
 - `--include-targets` filters the targets (resource types) for which this hook will be invoked. This can be passed as a comma-separated string (for example, `--include-targets "AWS::S3::*,AWS::DynamoDB::Table"`) (Default is ALL resource types).
 
-See the following example of how to run the `enable-lambda-function-invoker` command; note that you don't need to run this command from inside an existing Hook's project directory:
+Note: Unlike the others, you do not need to run this command from inside an existing Hooks project directory.
+
+See the following example of how to run the `enable-lambda-function-invoker` command; note that the `--region` argument needs to be passed here if the default region configured in your AWS CLI is **not** set to `us-east-2` (the same region in which the Lambda function exists).
 
 ```bash
 cfn hook enable-lambda-function-invoker \

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ To enable experimental commands: you will need to set the environment variable `
 
 To activate and set the type configuration of the `AWSSamples::LambdaFunctionInvoker::Hook`third-party [hook](https://github.com/aws-cloudformation/aws-cloudformation-samples/tree/main/hooks/python-hooks/lambda-function-invoker) in your AWS account, use the `enable-lambda-function-invoker` command.
 
-This hook will use the IAM role that you pass to `--execution-role-arn` to invoke the Lambda function that you pass to the `--lambda-function-arn` argument Optionally, `--failure-mode`, `--alias`, and `--include-targets` can all be specified with the following behavior:
+This hook will use the IAM role that you pass to `--execution-role-arn` to invoke the Lambda function that you pass to the `--lambda-function-arn` argument. Make sure the Lambda function is in the same region as the hook that you're activating; the Lambda function can also be in another account (but still, it needs to be in the same region as the hook). Ensure that the execution role IAM policy and the Lambda resource policy have been configured accordingly.
+
+Optionally, `--failure-mode`, `--alias`, and `--include-targets` can all be specified with the following behavior:
 
 - `--failure-mode` changes the failure mode to either `FAIL` or `WARN` (Default is `FAIL`).
 - `--alias` changes the type name for this hook in your account. For example, this can be used to change `AWSSamples::LambdaFunctionInvoker::Hook` to `MyCompany::MyOrganization::S3BucketCheckHook`.

--- a/README.md
+++ b/README.md
@@ -111,17 +111,18 @@ To enable experimental commands: you will need to set the environment variable `
 
 To activate and set the type configuration of the `AWSSamples::LambdaFunctionInvoker::Hook`third-party [hook](https://github.com/aws-cloudformation/aws-cloudformation-samples/tree/main/hooks/python-hooks/lambda-function-invoker) in your AWS account, use the `enable-lambda-function-invoker` command.
 
-This hook will invoke the Lambda function that is passed to the `--lambda-function-arn` argument. Optionally, `--failure-mode`, `--execution-role-arn`, `--alias`, and `--include-targets` can all be specified with the following behavior:
+This hook will use the IAM role that you pass to `--execution-role-arn` to invoke the Lambda function that you pass to the `--lambda-function-arn` argument Optionally, `--failure-mode`, `--alias`, and `--include-targets` can all be specified with the following behavior:
 
 - `--failure-mode` changes the failure mode to either `FAIL` or `WARN` (Default is `FAIL`).
-- `--execution-role-arn` changes the execution role for this hook to use during runtime (Default is the role used to activate the type).
-- `--alias` changes the type name for this hook in your account. For example, this can be used to change `AWSSamples::LambdaFunctionInvoker::Hook` to `MyCompany::MyOrganization::S3BucketCheckHook`. Note: If `alias` is specified, `execution-role-arn` must also be specified.
-- `--include-targets` filters the targets (resource types) for which this hook will be invoked. This can be passed as a comma-separated string (ex. `--include-targets "AWS::S3::*,AWS::DynamoDB::Table"`) (Default is ALL resource types).
+- `--alias` changes the type name for this hook in your account. For example, this can be used to change `AWSSamples::LambdaFunctionInvoker::Hook` to `MyCompany::MyOrganization::S3BucketCheckHook`.
+- `--include-targets` filters the targets (resource types) for which this hook will be invoked. This can be passed as a comma-separated string (for example, `--include-targets "AWS::S3::*,AWS::DynamoDB::Table"`) (Default is ALL resource types).
 
-Note: This command does not need to be run from inside an existing Hooks project directory.
+See the following example of how to run the `enable-lambda-function-invoker` command; note that you don't need to run this command from inside an existing Hook's project directory:
 
 ```bash
-cfn hook enable-lambda-function-invoker --lambda-function-arn arn:aws:lambda:us-east-2:123456789012:function:my-function:1
+cfn hook enable-lambda-function-invoker \
+--lambda-function-arn arn:aws:lambda:us-east-2:123456789012:function:my-function:1 \
+--execution-role-arn arn:aws:iam::123456789012:role/ExampleRole
 ```
 
 Sample output:

--- a/README.md
+++ b/README.md
@@ -105,28 +105,28 @@ ConfigurationArn: arn:aws:cloudformation:us-east-1:000000000000:type-configurati
 
 ## Experimental Commands
 
-To enable experimental commands: you can set the environment variable: `export CFN_CLI_HOOKS_EXPERIMENTAL=enabled`.
+To enable experimental commands: you will need to set the environment variable `CFN_CLI_HOOKS_EXPERIMENTAL` to `enabled`. Example for the Bash shell: `export CFN_CLI_HOOKS_EXPERIMENTAL=enabled`.
 
-### Command: enable-lambda-invoker
+### Command: enable-lambda-function-invoker
 
-To activate and set the type configuration of the `AWSSamples::LambdaInvoker::Hook` 3rd party hook, use the `enable-lambda-invoker` command.
+To activate and set the type configuration of the `AWSSamples::LambdaFunctionInvoker::Hook`third-party [hook](https://github.com/aws-cloudformation/aws-cloudformation-samples/tree/main/hooks/python-hooks/lambda-function-invoker) in your AWS account, use the `enable-lambda-function-invoker` command.
 
-This hook will invoke the lambda that is passed as the `lambda-arn` argument. Optionally, `failure-mode`, `execution-role-arn`, `alias`, and `include-targets` can all be specified with the following behavior:
+This hook will invoke the Lambda function that is passed to the `--lambda-function-arn` argument. Optionally, `--failure-mode`, `--execution-role-arn`, `--alias`, and `--include-targets` can all be specified with the following behavior:
 
-- `failure-mode` changes the failure mode to either `FAIL` or `WARN` (Default is `FAIL`).
-- `execution-role-arn` changes the execution role for this hook to use during runtime (Default is the role used to activate the type).
-- `alias` changes the type name for this hook in your account. For example, this can be used to change `AWSSamples::LambdaInvoker::Hook` to `MyCompany::MyOrganization::S3BucketCheckHook`. Note: If `alias` is specified, `execution-role-arn` must also be specified.
-- `include-targets` filters the targets (resource types) for which this hook will be invoked. This can be passed as a comma-seperated string (ex. `--include-targets "AWS::S3::*,AWS::DynamoDb::Table"`). (Default is ALL resource types)
+- `--failure-mode` changes the failure mode to either `FAIL` or `WARN` (Default is `FAIL`).
+- `--execution-role-arn` changes the execution role for this hook to use during runtime (Default is the role used to activate the type).
+- `--alias` changes the type name for this hook in your account. For example, this can be used to change `AWSSamples::LambdaFunctionInvoker::Hook` to `MyCompany::MyOrganization::S3BucketCheckHook`. Note: If `alias` is specified, `execution-role-arn` must also be specified.
+- `--include-targets` filters the targets (resource types) for which this hook will be invoked. This can be passed as a comma-separated string (ex. `--include-targets "AWS::S3::*,AWS::DynamoDB::Table"`) (Default is ALL resource types).
 
-Note: This command does not need to be run from inside an a pre-initialized Hooks project directory.
+Note: This command does not need to be run from inside an existing Hooks project directory.
 
 ```bash
-cfn hook enable-lambda-invoker --lambda-arn arn:aws:lambda:us-east-2:123456789012:function:my-function:1
+cfn hook enable-lambda-function-invoker --lambda-function-arn arn:aws:lambda:us-east-2:123456789012:function:my-function:1
 ```
 
 Sample output:
 ```
-Success: AWSSamples::LambdaInvoker::Hook will now be invoked for CloudFormation deployments for ALL resources in FAIL mode.
+Success: AWSSamples::LambdaFunctionInvoker::Hook will now be invoked for CloudFormation deployments for ALL resources in FAIL mode.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Sample output:
 ConfigurationArn: arn:aws:cloudformation:us-east-1:000000000000:type-configuration/hook/AWS-CloudFormation-SampleHook/default
 ```
 
+## Experimental Commands
+
+To enable experimental commands: you can set
+
 
 ## Development
 

--- a/src/hook_extension/configure_hook.py
+++ b/src/hook_extension/configure_hook.py
@@ -26,7 +26,7 @@ def _set_type_configuration(cfn_client, type_name: str, type_configuration_json:
         type_configuration_json (string): The json formatted string to use as the Hook's TypeConfiguration
 
     Returns:
-        None.
+       dict: The response from the SetTypeConfiguration API.
 
     Side effect: Type configuration of hook will be updated in AWS account.
     """

--- a/src/hook_extension/describe_hook.py
+++ b/src/hook_extension/describe_hook.py
@@ -185,8 +185,8 @@ def _build_target_handlers_string(cfn_client, versioned_hook_data: dict, hook_co
                     _matches_filters(
                         {
                             "TargetName": targetName,
-                            "Action": action,
-                            "InvocationPoint": invocation_point
+                            "Action": action, # pylint: disable=cell-var-from-loop
+                            "InvocationPoint": invocation_point # pylint: disable=cell-var-from-loop
                         },
                         hook_configuration_data["TargetFilters"]
                     ),

--- a/src/hook_extension/enable_lambda_hook.py
+++ b/src/hook_extension/enable_lambda_hook.py
@@ -149,7 +149,8 @@ def _enable_lambda_invoker(args: Namespace) -> None:
     configuration_json = _build_configuration_json_string(args.lambda_arn, args.failure_mode, args.include_targets)
     _set_type_configuration(cfn_client, lambda_hook_arn, configuration_json)
 
-    print(f"Success: {args.alias or 'AWSSamples::LambdaInvoker::Hook'} will now be invoked for CloudFormation deployments for {args.include_targets or 'ALL'} resources in {args.failure_mode or 'FAIL'} mode")
+    print(f"Success: {args.alias or 'AWSSamples::LambdaInvoker::Hook'} will now be invoked " +
+            f"for CloudFormation deployments for {args.include_targets or 'ALL'} resources in {args.failure_mode or 'FAIL'} mode.")
 
 def setup_parser(parser):
     enable_lambda_invoker_subparser = parser.add_parser(COMMAND_NAME, description=__doc__)

--- a/src/hook_extension/enable_lambda_hook.py
+++ b/src/hook_extension/enable_lambda_hook.py
@@ -1,0 +1,100 @@
+"""
+This sub command sets the type configuration of the hook registered in your AWS account.
+"""
+import logging
+import json
+from argparse import Namespace
+
+from botocore.exceptions import ClientError
+
+from rpdk.core.boto_helpers import create_sdk_session
+from rpdk.core.exceptions import DownstreamError
+
+LOG = logging.getLogger(__name__)
+
+COMMAND_NAME = "enable-lambda-invoker"
+
+
+def _activate_lambda_invoker(cfn_client, execution_role_arn: str, alias: str) -> None:
+    kwargs = {
+        "TypeName": "AWSSamples::LambdaFunctionInvoker::Hook",
+        "Type": "HOOK",
+        "PublisherId": "096debcd443a84c983955f8f8476c221b2b08d8b"
+    }
+    if execution_role_arn:
+        kwargs["ExecutionRoleArn"] = execution_role_arn
+    if alias:
+        kwargs["TypeNameAlias"] = alias
+    LOG.debug("Calling ActivateType with input: %s", kwargs)
+    try:
+        response = cfn_client.activate_type(**kwargs)
+        LOG.debug("Successful response from ActivateType")
+        return response
+    except cfn_client.exceptions.TypeNotFoundException as e:
+        msg = "Setting type configuration resulted in TypeNotFoundException."
+        print("\n" + msg)
+        raise DownstreamError(msg) from e
+    except ClientError as e:
+        raise DownstreamError from e
+
+def _set_type_configuration(cfn_client, type_arn: str, type_configuration_json: str) -> None:
+    """
+    Sets Hook type configuration by calling CloudFormation SetTypeConfiguration API with arguments.
+    https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_SetTypeConfiguration.html
+
+    Parameters:
+        cfn_client: Boto3 session CloudFormation client.
+        type_arn (string): The ARN for the hook to call SetTypeConfiguration with.
+        type_configuration_json (string): The json formatted string to use as the Hook's TypeConfiguration
+
+    Returns:
+        None.
+
+    Side effect: Type configuration of hook will be updated in AWS account.
+    """
+    LOG.debug("Calling SetTypeConfiguration for %s", type_arn)
+    try:
+        response = cfn_client.set_type_configuration(TypeArn=type_arn, Configuration=type_configuration_json)
+        LOG.debug("Successful response from SetTypeConfiguration")
+        return response
+    except cfn_client.exceptions.TypeNotFoundException as e:
+        msg = "Setting type configuration resulted in TypeNotFoundException. Have you registered this hook first?"
+        print("\n" + msg)
+        raise DownstreamError(msg) from e
+    except ClientError as e:
+        raise DownstreamError from e
+
+def _enable_lambda_invoker(args: Namespace) -> None:
+    """
+    Main method for the hook enable-lambda-invoker command. Uses file path specified to set the type configuration of the Hook in AWS.
+
+    """
+    cfn_client = create_sdk_session(args.region, args.profile).client("cloudformation", endpoint_url=args.endpoint_url)
+
+    lambda_hook_arn = _activate_lambda_invoker(cfn_client, args.execution_role, args.alias)["Arn"]
+
+    configuration_json = json.dumps({
+        "CloudFormationConfiguration":{
+            "HookConfiguration": {
+                "FailureMode": args.failure_mode if args.failure_mode else "FAIL",
+                "TargetStacks": "ALL",
+                "Properties":{
+                    "LambdaFunctions": [args.lambda_arn]
+                }
+            }
+        }
+
+    })
+
+    set_type_config_response = _set_type_configuration(cfn_client, lambda_hook_arn, configuration_json)
+
+def setup_parser(parser):
+    enable_lambda_invoker_subparser = parser.add_parser(COMMAND_NAME, description=__doc__)
+    enable_lambda_invoker_subparser.set_defaults(command=_enable_lambda_invoker)
+    enable_lambda_invoker_subparser.add_argument("--lambda-arn", help="Lambda function ARN to use for the hook.", required=True)
+    enable_lambda_invoker_subparser.add_argument("--failure-mode", help="Failure mode to configure for hook. Valid values: [WARN, FAIL]. Default is FAIL.")
+    enable_lambda_invoker_subparser.add_argument("--execution-role", help="ARN of the IAM role to use for hook execution.")
+    enable_lambda_invoker_subparser.add_argument("--alias", help="Alias to use for AWSSamples::LambdaFunctionInvoker::Hook")
+    enable_lambda_invoker_subparser.add_argument("--profile", help="AWS profile to use.")
+    enable_lambda_invoker_subparser.add_argument("--endpoint-url", help="CloudFormation endpoint to use.")
+    enable_lambda_invoker_subparser.add_argument("--region", help="AWS Region to submit the type.")

--- a/src/hook_extension/entry.py
+++ b/src/hook_extension/entry.py
@@ -9,6 +9,7 @@ from .__init__ import __version__
 from .describe_hook import setup_parser as setup_describe_parser
 from .configure_hook import setup_parser as setup_configure_parser
 from .set_default_hook_version import setup_parser as setup_set_default_version_parser
+from .enable_lambda_hook import setup_parser as setup_enable_lambda_invoker_parser
 
 LOG = logging.getLogger(__name__)
 
@@ -40,3 +41,4 @@ class HookExtension(ExtensionPlugin):
         setup_describe_parser(hook_parser)
         setup_configure_parser(hook_parser)
         setup_set_default_version_parser(hook_parser)
+        setup_enable_lambda_invoker_parser(hook_parser)

--- a/tests/test_enable_lambda_hook.py
+++ b/tests/test_enable_lambda_hook.py
@@ -360,7 +360,7 @@ class TestEnableLambdaInvoker:
 
         out, _ = capsys.readouterr()
 
-        expected = "Success: AWSSamples::LambdaInvoker::Hook will now be invoked for CloudFormation deployments for ALL resources in FAIL mode\n"
+        expected = "Success: AWSSamples::LambdaInvoker::Hook will now be invoked for CloudFormation deployments for ALL resources in FAIL mode.\n"
 
         assert out == expected
 
@@ -434,6 +434,6 @@ class TestEnableLambdaInvoker:
                 _enable_lambda_invoker(args)
 
         out, _ = capsys.readouterr()
-        expected = "Success: AWSSamples::LambdaInvoker::Hook will now be invoked for CloudFormation deployments for AWS::SQS::Queue,AWS::Cloud*::* resources in FAIL mode\n"
+        expected = "Success: AWSSamples::LambdaInvoker::Hook will now be invoked for CloudFormation deployments for AWS::SQS::Queue,AWS::Cloud*::* resources in FAIL mode.\n"
 
         assert out == expected

--- a/tests/test_enable_lambda_hook.py
+++ b/tests/test_enable_lambda_hook.py
@@ -1,0 +1,439 @@
+# pylint: disable=protected-access,redefined-outer-name
+import os
+import json
+from unittest.mock import Mock, patch
+from argparse import ArgumentParser
+import pytest
+
+from botocore.stub import Stubber
+
+from rpdk.core.boto_helpers import create_sdk_session
+from rpdk.core.exceptions import DownstreamError, SysExitRecommendedError
+from rpdk.core.cli import main
+
+from hook_extension.enable_lambda_hook import (
+    setup_parser,
+    _activate_lambda_invoker,
+    _set_type_configuration,
+    _enable_lambda_invoker,
+    _build_configuration_json_string
+)
+
+DUMMY_LAMBDA_ARN = "arn:aws:lambda:us-east-2:123456789012:function:my-function:1"
+DUMMY_EXECUTION_ROLE_ARN = "arn:aws:iam::123456789012:role/my-role"
+
+@pytest.fixture
+def cfn_client():
+    return create_sdk_session().client("cloudformation")
+
+class TestEntryPoint:
+    def test_command_available(self):
+        patch_enable_lambda_invoker_hook = patch(
+            "hook_extension.enable_lambda_hook._enable_lambda_invoker", autospec=True
+        )
+        with patch_enable_lambda_invoker_hook as mock_configure_hook:
+            main(args_in=["hook", "enable-lambda-invoker", "--lambda-arn", DUMMY_LAMBDA_ARN])
+
+        mock_configure_hook.assert_called_once()
+
+    def test_command_without_required_args_fails(self):
+        patch_enable_lambda_invoker_hook = patch(
+            "hook_extension.enable_lambda_hook._enable_lambda_invoker", autospec=True
+        )
+        with patch_enable_lambda_invoker_hook, pytest.raises(SystemExit):
+            main(args_in=["hook", "enable-lambda-invoker"])
+
+@pytest.mark.parametrize(
+        "args_in, expected",
+        [
+            (["--region", "us-west-2", "--lambda-arn", DUMMY_LAMBDA_ARN],
+                {"region": "us-west-2", "profile": None, "endpoint_url": None, "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": None, "execution_role": None, "alias": None, "include_targets": None}),
+            (["--profile", "sandbox", "--lambda-arn", DUMMY_LAMBDA_ARN],
+                {"region": None, "profile": "sandbox", "endpoint_url": None, "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": None, "execution_role": None, "alias": None, "include_targets": None}),
+            (["--endpoint-url", "https://my_endpoint.my_domain", "--lambda-arn", DUMMY_LAMBDA_ARN],
+                {"region": None, "profile": None, "endpoint_url": "https://my_endpoint.my_domain", "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": None, "execution_role": None, "alias": None, "include_targets": None}),
+            (["--failure-mode", "WARN", "--lambda-arn", DUMMY_LAMBDA_ARN],
+                {"region": None, "profile": None, "endpoint_url": None, "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": "WARN", "execution_role": None, "alias": None, "include_targets": None}),
+            (["--execution-role", "arn:aws:iam::123456789012:role/my-role", "--lambda-arn", DUMMY_LAMBDA_ARN],
+                {"region": None, "profile": None, "endpoint_url": None, "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": None, "execution_role": "arn:aws:iam::123456789012:role/my-role", "alias": None, "include_targets": None}),
+            (["--alias", "Test::Alias::Hook", "--lambda-arn", DUMMY_LAMBDA_ARN],
+                {"region": None, "profile": None, "endpoint_url": None, "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": None, "execution_role": None, "alias": "Test::Alias::Hook", "include_targets": None}),
+            (["--include-targets", "AWS::S3::*,AWS::*::Table", "--lambda-arn", DUMMY_LAMBDA_ARN],
+                {"region": None, "profile": None, "endpoint_url": None, "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": None, "execution_role": None, "alias": None, "include_targets": "AWS::S3::*,AWS::*::Table"}),
+            (["--lambda-arn", DUMMY_LAMBDA_ARN],
+                {"region": None, "profile": None, "endpoint_url": None, "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": None, "execution_role": None, "alias": None, "include_targets": None}),
+            (["--region", "us-west-2", "--profile", "sandbox", "--lambda-arn", DUMMY_LAMBDA_ARN],
+                {"region": "us-west-2", "profile": "sandbox", "endpoint_url": None, "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": None, "execution_role": None, "alias": None, "include_targets": None}),
+            (["--region", "us-west-2", "--profile", "sandbox", "--endpoint-url", "https://my_endpoint.my_domain", "--lambda-arn", DUMMY_LAMBDA_ARN],
+                {"region": "us-west-2", "profile": "sandbox", "endpoint_url": "https://my_endpoint.my_domain", "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": None, "execution_role": None, "alias": None, "include_targets": None}),
+            (["--region", "us-west-2", "--profile", "sandbox", "--endpoint-url", "https://my_endpoint.my_domain", "--lambda-arn", DUMMY_LAMBDA_ARN, "--failure-mode", "FAIL",
+              "--execution-role", "arn:aws:iam::123456789012:role/my-role-2", "--alias", "NewTest::NewAlias::Hook2", "--include-targets", "AWS::*::*"],
+                {"region": "us-west-2", "profile": "sandbox", "endpoint_url": "https://my_endpoint.my_domain", "lambda_arn": DUMMY_LAMBDA_ARN,
+                 "failure_mode": "FAIL", "execution_role": "arn:aws:iam::123456789012:role/my-role-2", "alias": "NewTest::NewAlias::Hook2", "include_targets": "AWS::*::*"})
+        ]
+    )
+class TestCommandLineArguments:
+    def test_parser(self, args_in, expected):
+        hook_parser = ArgumentParser()
+        setup_parser(hook_parser.add_subparsers())
+        parsed = hook_parser.parse_args(["enable-lambda-invoker"] + args_in)
+        assert parsed.region == expected["region"]
+        assert parsed.profile == expected["profile"]
+        assert parsed.endpoint_url == expected["endpoint_url"]
+        assert parsed.lambda_arn == expected["lambda_arn"]
+
+    def test_args_passed(self, args_in, expected):
+        patch_enable_lambda_invoker = patch(
+            "hook_extension.enable_lambda_hook._enable_lambda_invoker", autospec=True
+        )
+
+        with patch_enable_lambda_invoker as mock_enable_lambda_invoker:
+            main(args_in=["hook", "enable-lambda-invoker"] + args_in)
+        mock_enable_lambda_invoker.assert_called_once()
+        argparse_namespace = mock_enable_lambda_invoker.call_args.args[0]
+        assert argparse_namespace.region == expected["region"]
+        assert argparse_namespace.profile == expected["profile"]
+        assert argparse_namespace.endpoint_url == expected["endpoint_url"]
+        assert argparse_namespace.lambda_arn == expected["lambda_arn"]
+
+class TestSetTypeConfiguration:
+    def test_set_type_configuration_happy(self, cfn_client):
+        response = ({
+            "ConfigurationArn": "TestArn"
+        })
+
+        with Stubber(cfn_client) as stubber:
+            stubber.add_response(
+                "set_type_configuration",
+                response,
+                { "TypeArn": "TestTypeArn", "Configuration": "TestConfiguration" }
+            )
+            output = _set_type_configuration(cfn_client, "TestTypeArn", "TestConfiguration")
+        assert output == response
+
+    def test_set_type_configuration_type_not_found(self, cfn_client):
+        with Stubber(cfn_client) as stubber, pytest.raises(Exception) as e:
+            stubber.add_client_error(
+                "set_type_configuration",
+                service_error_code="TypeNotFoundException",
+                expected_params={ "TypeArn": "TestTypeArn", "Configuration": "TestConfiguration" }
+            )
+            _set_type_configuration(cfn_client, "TestTypeArn", "TestConfiguration")
+        assert e.type == DownstreamError
+
+    def test_set_type_configuration_client_error(self, cfn_client):
+        with Stubber(cfn_client) as stubber, pytest.raises(Exception) as e:
+            stubber.add_client_error(
+                "set_type_configuration",
+                service_error_code="CFNRegistryException",
+                expected_params={ "TypeArn": "TestTypeArn", "Configuration": "TestConfiguration" }
+            )
+            _set_type_configuration(cfn_client, "TestTypeArn", "TestConfiguration")
+        assert e.type == DownstreamError
+
+@pytest.mark.parametrize(
+        "execution_role_arn, alias",
+        [(None, None),
+         (DUMMY_EXECUTION_ROLE_ARN, None),
+         (None, "Test::MyAlias::Hook"),
+         (DUMMY_EXECUTION_ROLE_ARN, "Test::MyAlias::Hook")]
+    )
+class TestActivateLambdaInvoker:
+    def test_activate_type_happy(self, cfn_client, execution_role_arn, alias):
+        response = ({
+            "Arn": "arn:aws:cloudformation:us-west-2:123456789012:type/resource/Example-Test-Alias"
+        })
+
+        expected_params = {
+            "TypeName": "AWSSamples::LambdaFunctionInvoker::Hook",
+            "Type": "HOOK",
+            "PublisherId": "096debcd443a84c983955f8f8476c221b2b08d8b"
+        }
+        if execution_role_arn:
+            expected_params["ExecutionRoleArn"] =  execution_role_arn
+        if alias:
+            expected_params["TypeNameAlias"] =  alias
+
+        with Stubber(cfn_client) as stubber:
+            stubber.add_response(
+                "activate_type",
+                response,
+                expected_params
+            )
+            output = _activate_lambda_invoker(cfn_client, execution_role_arn, alias)
+        assert output == response
+
+    def test_activate_type_type_not_found(self, cfn_client, execution_role_arn, alias):
+        expected_params = {
+            "TypeName": "AWSSamples::LambdaFunctionInvoker::Hook",
+            "Type": "HOOK",
+            "PublisherId": "096debcd443a84c983955f8f8476c221b2b08d8b"
+        }
+        if execution_role_arn:
+            expected_params["ExecutionRoleArn"] =  execution_role_arn
+        if alias:
+            expected_params["TypeNameAlias"] =  alias
+
+        with Stubber(cfn_client) as stubber, pytest.raises(Exception) as e:
+            stubber.add_client_error(
+                "activate_type",
+                service_error_code="TypeNotFoundException",
+                expected_params=expected_params
+            )
+            _activate_lambda_invoker(cfn_client, execution_role_arn, alias)
+        assert e.type == DownstreamError
+
+    def test_activate_type_client_error(self, cfn_client, execution_role_arn, alias):
+        expected_params = {
+            "TypeName": "AWSSamples::LambdaFunctionInvoker::Hook",
+            "Type": "HOOK",
+            "PublisherId": "096debcd443a84c983955f8f8476c221b2b08d8b"
+        }
+        if execution_role_arn:
+            expected_params["ExecutionRoleArn"] =  execution_role_arn
+        if alias:
+            expected_params["TypeNameAlias"] =  alias
+
+        with Stubber(cfn_client) as stubber, pytest.raises(Exception) as e:
+            stubber.add_client_error(
+                "activate_type",
+                service_error_code="CFNRegistryException",
+                expected_params=expected_params
+            )
+            _activate_lambda_invoker(cfn_client, execution_role_arn, alias)
+        assert e.type == DownstreamError
+
+class TestBuildConfigurationJsonString:
+    @pytest.mark.parametrize("lambda_arn", [DUMMY_LAMBDA_ARN, "AnotherLambdaArn"])
+    @pytest.mark.parametrize("failure_mode", ["WARN", "FAIL"])
+    def test_build_configuration_json_string_no_include_targets(self, lambda_arn, failure_mode):
+        configuration_string = _build_configuration_json_string(lambda_arn, failure_mode, None)
+        configuration_object = json.loads(configuration_string)
+
+        assert "TargetFilters" not in configuration_object
+        assert configuration_object["CloudFormationConfiguration"]["HookConfiguration"]["FailureMode"] == failure_mode
+        assert configuration_object["CloudFormationConfiguration"]["HookConfiguration"]["TargetStacks"] == "ALL"
+        assert configuration_object["CloudFormationConfiguration"]["HookConfiguration"]["Properties"]["LambdaFunctions"] == [lambda_arn]
+
+    @pytest.mark.parametrize("lambda_arn", [DUMMY_LAMBDA_ARN, "AnotherLambdaArn"])
+    @pytest.mark.parametrize("failure_mode", ["WARN", "FAIL"])
+    @pytest.mark.parametrize("include_targets, expected_targets", [("AWS::S3::Bucket", ["AWS::S3::Bucket"]), ("AWS::Cloud*::*,AWS::DynamoDb::Table", ["AWS::Cloud*::*", "AWS::DynamoDb::Table"])])
+    def test_build_configuration_json_string_with_include_targets(self, lambda_arn, failure_mode, include_targets, expected_targets):
+        configuration_string = _build_configuration_json_string(lambda_arn, failure_mode, include_targets)
+        configuration_object = json.loads(configuration_string)
+
+        assert configuration_object["CloudFormationConfiguration"]["HookConfiguration"]["FailureMode"] == failure_mode
+        assert configuration_object["CloudFormationConfiguration"]["HookConfiguration"]["TargetStacks"] == "ALL"
+        assert configuration_object["CloudFormationConfiguration"]["HookConfiguration"]["Properties"]["LambdaFunctions"] == [lambda_arn]
+        assert configuration_object["CloudFormationConfiguration"]["HookConfiguration"]["TargetFilters"]["Actions"] == ["CREATE", "UPDATE"]
+        assert configuration_object["CloudFormationConfiguration"]["HookConfiguration"]["TargetFilters"]["InvocationPoints"] == ["PRE_PROVISION"]
+        assert configuration_object["CloudFormationConfiguration"]["HookConfiguration"]["TargetFilters"]["TargetNames"] == expected_targets
+
+
+class TestEnableLambdaInvoker:
+    def test_enable_lambda_invoker_no_experimental_flag(self):
+        os.environ["CFN_CLI_HOOKS_EXPERIMENTAL"] = ""
+
+        args = Mock(
+            spec_set=[
+                "region",
+                "profile",
+                "endpoint_url",
+                "lambda_arn",
+                "failure_mode",
+                "execution_role",
+                "alias",
+                "include_targets"
+            ]
+        )
+        args.region=None
+        args.profile=None
+        args.endpoint_url=None
+        args.lambda_arn=DUMMY_LAMBDA_ARN
+        args.failure_mode=None
+        args.execution_role=None
+        args.alias=None
+        args.include_targets=None
+
+        with pytest.raises(Exception) as e:
+            _enable_lambda_invoker(args)
+
+        assert e.type == SysExitRecommendedError
+
+    @pytest.mark.parametrize("input_value", ["n", "N", "", "adsfas", "1"])
+    def test_enable_lambda_invoker_no_include_targets_abort(self, input_value):
+        os.environ["CFN_CLI_HOOKS_EXPERIMENTAL"] = "enabled"
+        args = Mock(
+            spec_set=[
+                "region",
+                "profile",
+                "endpoint_url",
+                "lambda_arn",
+                "failure_mode",
+                "execution_role",
+                "alias",
+                "include_targets"
+            ]
+        )
+        args.region=None
+        args.profile=None
+        args.endpoint_url=None
+        args.lambda_arn=DUMMY_LAMBDA_ARN
+        args.failure_mode=None
+        args.execution_role=None
+        args.alias=None
+        args.include_targets=None
+
+        patch_input = patch("builtins.input", return_value=input_value)
+        with patch_input, pytest.raises(Exception) as e:
+            _enable_lambda_invoker(args)
+
+        assert e.type == SysExitRecommendedError
+
+    @pytest.mark.parametrize("input_value", ["y", "Y"])
+    def test_enable_lambda_invoker_no_include_targets_continue(self, capsys, cfn_client, input_value):
+        os.environ["CFN_CLI_HOOKS_EXPERIMENTAL"] = "enabled"
+        args = Mock(
+            spec_set=[
+                "region",
+                "profile",
+                "endpoint_url",
+                "lambda_arn",
+                "failure_mode",
+                "execution_role",
+                "alias",
+                "include_targets"
+            ]
+        )
+        args.region=None
+        args.profile=None
+        args.endpoint_url=None
+        args.lambda_arn=DUMMY_LAMBDA_ARN
+        args.failure_mode=None
+        args.execution_role=None
+        args.alias=None
+        args.include_targets=None
+
+        patch_sdk = patch("boto3.session.Session.client", autospec=True, return_value = cfn_client)
+        patch_input = patch("builtins.input", return_value=input_value)
+        with patch_sdk, patch_input:
+            with Stubber(cfn_client) as stubber:
+                stubber.add_response(
+                    "activate_type",
+                    { "Arn": "DummyTypeArn" },
+                    {
+                        "TypeName": "AWSSamples::LambdaFunctionInvoker::Hook",
+                        "Type": "HOOK",
+                        "PublisherId": "096debcd443a84c983955f8f8476c221b2b08d8b"
+                    }
+                )
+                stubber.add_response(
+                    "set_type_configuration",
+                    { "ConfigurationArn": "TestArn" },
+                    { "TypeArn": "DummyTypeArn",
+                     "Configuration": json.dumps(
+                         {
+                             "CloudFormationConfiguration":{
+                                    "HookConfiguration": {
+                                        "FailureMode": "FAIL",
+                                        "TargetStacks": "ALL",
+                                        "Properties":{
+                                            "LambdaFunctions": [DUMMY_LAMBDA_ARN]
+                                        }
+                                    }
+                                }
+                         }
+                     ) }
+
+                )
+                _enable_lambda_invoker(args)
+
+        out, _ = capsys.readouterr()
+
+        expected = "Success: AWSSamples::LambdaInvoker::Hook will now be invoked for CloudFormation deployments for ALL resources in FAIL mode\n"
+
+        assert out == expected
+
+    def test_enable_lambda_invoker_basic_happy_path(self, capsys, cfn_client):
+        os.environ["CFN_CLI_HOOKS_EXPERIMENTAL"] = "enabled"
+        args = Mock(
+            spec_set=[
+                "region",
+                "profile",
+                "endpoint_url",
+                "lambda_arn",
+                "failure_mode",
+                "execution_role",
+                "alias",
+                "include_targets"
+            ]
+        )
+        args.region=None
+        args.profile=None
+        args.endpoint_url=None
+        args.lambda_arn=DUMMY_LAMBDA_ARN
+        args.failure_mode=None
+        args.execution_role=None
+        args.alias=None
+        args.include_targets="AWS::SQS::Queue,AWS::Cloud*::*"
+
+        patch_sdk = patch("boto3.session.Session.client", autospec=True, return_value = cfn_client)
+        with patch_sdk:
+            with Stubber(cfn_client) as stubber:
+                stubber.add_response(
+                    "activate_type",
+                    { "Arn": "DummyTypeArn" },
+                    {
+                        "TypeName": "AWSSamples::LambdaFunctionInvoker::Hook",
+                        "Type": "HOOK",
+                        "PublisherId": "096debcd443a84c983955f8f8476c221b2b08d8b"
+                    }
+                )
+                stubber.add_response(
+                    "set_type_configuration",
+                    { "ConfigurationArn": "TestArn" },
+                    { "TypeArn": "DummyTypeArn",
+                     "Configuration": json.dumps(
+                         {
+                             "CloudFormationConfiguration":{
+                                    "HookConfiguration": {
+                                        "FailureMode": "FAIL",
+                                        "TargetStacks": "ALL",
+                                        "Properties":{
+                                            "LambdaFunctions": [DUMMY_LAMBDA_ARN]
+                                        },
+                                        "TargetFilters": {
+                                            "TargetNames": [
+                                                "AWS::SQS::Queue",
+                                                "AWS::Cloud*::*"
+                                            ],
+                                            "Actions": [
+                                                "CREATE",
+                                                "UPDATE"
+                                            ],
+                                            "InvocationPoints": [
+                                                "PRE_PROVISION"
+                                            ]
+                                        }
+                                    }
+                                }
+                         }
+                     ) }
+
+                )
+                _enable_lambda_invoker(args)
+
+        out, _ = capsys.readouterr()
+        expected = "Success: AWSSamples::LambdaInvoker::Hook will now be invoked for CloudFormation deployments for AWS::SQS::Queue,AWS::Cloud*::* resources in FAIL mode\n"
+
+        assert out == expected


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Adding a new "experimental commands" concept. Command implementation simply checks that the Environment variable `CFN_CLI_HOOKS_EXPERIMENTAL` is set to `enabled` before executing command. 
- Adding a new `enable-lambda-invoker` command that makes two API calls to registry: 1. `ActivateType` for the `AWSSamples::LambdaInvoker::Hook` that is published publicly in every region and 2. `SetTypeConfiguration` for that newly activated type to configure it to start targeting stacks. 
- This new command allows customers to enable their lambda hook with one simple command from the CLI
- Unit tests added for all functions

Pytest results:
```
(venv) ➜  cloudformation-cli-hooks-extension git:(enable-lambda-invoker) coverage run --source=. -m pytest
============================================================== test session starts ==============================================================
platform darwin -- Python 3.11.3, pytest-7.4.2, pluggy-1.3.0
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/workplace/cloudformation-cli/cloudformation-cli-hooks-extension
plugins: random-order-1.1.0, hypothesis-6.86.2, cov-4.1.0, localserver-0.8.0
collected 171 items                                                                                                                             

tests/test_configure_hook.py ...................                                                                                          [ 11%]
tests/test_describe_hook.py ........................................................................                                      [ 53%]
tests/test_enable_lambda_hook.py ............................................................                                             [ 88%]
tests/test_hook_extension.py ..                                                                                                           [ 89%]
tests/test_set_default_hook_version.py ..................                                                                                 [100%]

=============================================================== warnings summary ================================================================
../venv/lib/python3.11/site-packages/rpdk/core/data_loaders.py:9
  /Volumes/workplace/cloudformation-cli/venv/lib/python3.11/site-packages/rpdk/core/data_loaders.py:9: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================== 171 passed, 1 warning in 5.30s =========================================================
```

Coverage report:
```
(venv) ➜  cloudformation-cli-hooks-extension git:(enable-lambda-invoker) coverage report                                                   
Name                                             Stmts   Miss  Cover
--------------------------------------------------------------------
setup.py                                            15     15     0%
src/hook_extension/__init__.py                       3      0   100%
src/hook_extension/configure_hook.py                42      0   100%
src/hook_extension/describe_hook.py                143      0   100%
src/hook_extension/enable_lambda_hook.py            68      0   100%
src/hook_extension/entry.py                         24      0   100%
src/hook_extension/set_default_hook_version.py      33      0   100%
tests/test_configure_hook.py                        94      0   100%
tests/test_describe_hook.py                        306      2    99%
tests/test_enable_lambda_hook.py                   190      0   100%
tests/test_hook_extension.py                        13      0   100%
tests/test_set_default_hook_version.py              75      0   100%
--------------------------------------------------------------------
TOTAL                                             1006     17    98%
```

Pylint results:
```
(venv) ➜  cloudformation-cli-hooks-extension git:(enable-lambda-invoker) pylint src/    

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
